### PR TITLE
get_optimal_threshold.m

### DIFF
--- a/analysis/create_project_figures.m
+++ b/analysis/create_project_figures.m
@@ -322,6 +322,9 @@ poor_patient_indices = find([hasData_field{:}] & strcmp(outcome_field,'poor'));
 good_z_score_results = cell(num_good_patients,1);
 good_resected_z_score_results = cell(num_good_patients,1);
 
+threshold_results = NaN(num_good_patients,5);
+threshold_accuracies = NaN(num_good_patients,5);
+
 % to hold logistic regression results
 mnr_results = cell(5,3);
 mdl_results = cell(5,1);
@@ -361,6 +364,10 @@ for test_band = 1:5
         % place results into all_patients
         all_patients(good_patient_indices(s)).z_scores(test_band).data.non_resected = good_z_score_results{s};
         all_patients(good_patient_indices(s)).z_scores(test_band).data.resected = good_resected_z_score_results{s};
+        
+        if strcmp(test_patient.therapy,'Ablation')
+            [threshold_results(s,test_band),threshold_accuracies(s,test_band)] = get_optimal_threshold(good_z_score_results{s},good_resected_z_score_results{s});
+        end
         
         fprintf(repmat('\b',1,line_length))
         
@@ -598,8 +605,13 @@ for test_band = 1:5
     
     mdl = fitglm(predictors,outcomes,'Distribution','binomial','Link','logit');
     mdl_results(test_band) = {mdl};
+    
+    close all
 end
 fprintf('\n')
+
+% get average threshold values for each band
+avg_thresholds = nanmean(threshold_results,1);
 
 % remove some variables from memory
 vars = {'B','get_average_data','good_distances','good_means', ...

--- a/util/get_optimal_threshold.m
+++ b/util/get_optimal_threshold.m
@@ -1,0 +1,43 @@
+function [optimal_threshold, best_accuracy] = get_optimal_threshold(non_resected_z_scores, resected_z_scores)
+%GET_OPTIMAL_THRESHOLD returns the z-value that is most predictive of
+%   resected vs. non-resected regions in a patient. Also returns the
+%   corresponding accuracy for the z-value
+
+% helper function
+get_data = @(x) x(triu(true(size(x))));
+
+min_z = min(min(non_resected_z_scores(:)),min(resected_z_scores(:)));
+max_z = max(max(non_resected_z_scores(:)),max(resected_z_scores(:)));
+
+% placeholders
+optimal_threshold = min_z;
+best_accuracy = 0;
+
+% number of steps to take between the min and max z-score
+steps = 100;
+
+% get z-scores, discarding NaNs
+non_res = get_data(non_resected_z_scores);
+res = get_data(resected_z_scores);
+    
+non_res = non_res(~isnan(non_res));
+res = res(~isnan(res));
+
+% determine threshold values to test
+for test_threshold = linspace(min_z,max_z,steps)
+    
+    correct_non_resected = non_res < test_threshold;
+    correct_resected = res > test_threshold;
+    
+    % calculate proportion of correct guesses
+    accuracy = mean([correct_non_resected; correct_resected]);
+    
+    % update optimal_threshold if the test threshold produces a new highest
+    % accuracy
+    if accuracy > best_accuracy
+        optimal_threshold = test_threshold;
+        best_accuracy = accuracy;
+    end
+    
+end
+


### PR DESCRIPTION
I added a new function which calculates the optimal z-score threshold for abnormality for a given patient's resected and non-resected z-score matrices. The function will also output the corresponding accuracy for the optimal threshold found. Patient-averaged thresholds by band can be calculated by running the cross-validation section in create_project_figures.